### PR TITLE
Only listen to resize events from the iframe

### DIFF
--- a/client.ts
+++ b/client.ts
@@ -12,7 +12,7 @@ function loadScript(url: string, callback: VoidFunction) {
 }
 
 loadScript('https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.1/iframeResizer.min.js', () =>
-  iFrameResize({ checkOrigin: [giscusOrigin] }),
+  iFrameResize({ checkOrigin: [giscusOrigin], resizeFrom: 'child' }),
 );
 
 // Set up iframe src URL and params


### PR DESCRIPTION
By default, iFrameResizer [listens to resize events from the parent page](https://github.com/davidjbradshaw/iframe-resizer/blob/master/docs/parent_page/options.md#resizefrom). Unfortunately, using giscus' client script in an SPA will leave the event listener intact, even if the `<iframe>` element is no longer there (e.g. the user moves to a different page). We cannot use iFrameResizer's react, vue, or other client libraries because we cannot know the specifics of the host website.

This PR changes the iFrameResizer config to only listen to resize events from the child element, meaning that it will only resize if the giscus widget is resized. When the `<iframe>` no longer exists in the page, (I think) the event won't be fired again.

See https://github.com/davidjbradshaw/iframe-resizer/issues/566.