### PR TITLE
Add default CSS in client script

### DIFF
--- a/client.ts
+++ b/client.ts
@@ -94,6 +94,21 @@ const iframeAttributes = {
 };
 Object.entries(iframeAttributes).forEach(([key, value]) => iframeElement.setAttribute(key, value));
 
+// Create default style and prepend as <head>'s first child to make override possible.
+const style = document.getElementById('giscus-css') || document.createElement('style');
+style.id = 'giscus-css';
+style.textContent = `
+  .giscus, .giscus-frame {
+    width: 100%;
+  }
+
+  .giscus-frame {
+    border: none;
+    color-scheme: auto;
+  }
+`;
+document.head.prepend(style);
+
 // Insert iframe element
 const existingContainer = document.querySelector('.giscus');
 if (!existingContainer) {

--- a/components/Configuration.tsx
+++ b/components/Configuration.tsx
@@ -358,24 +358,8 @@ export default function Configuration({ directConfig, onDirectConfigChange }: Co
       </div>
       <p>
         You can customize the layout using the <code>.giscus</code> and <code>.giscus-frame</code>{' '}
-        selectors. For example, you can add the following rules to your CSS file.
+        selectors.
       </p>
-      <div className="relative highlight highlight-source-css">
-        <pre>
-          .<span className="pl-c1">giscus</span>
-          <span className="pl-kos">,</span> .<span className="pl-c1">giscus-frame</span> {'{\n  '}
-          <span className="pl-c1">width</span>
-          <span className="pl-kos">:</span>{' '}
-          <span className="pl-c1">
-            100<span className="pl-smi">%</span>
-          </span>
-          ;{'\n}\n\n'}.<span className="pl-c1">giscus-frame</span> {'{\n  '}
-          <span className="pl-c1">border</span>
-          <span className="pl-kos">:</span> none;
-          {'\n}'}
-        </pre>
-        <ClipboardCopy />
-      </div>
     </div>
   );
 }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -97,16 +97,7 @@ export default function Home({ contentBefore, contentAfter }: HomeProps) {
               />
             </Comment>
 
-            <div className="w-full my-8 giscus color-bg-canvas">
-              <style jsx>
-                {`
-                  :global(.giscus-frame) {
-                    width: 100%;
-                    color-scheme: auto;
-                  }
-                `}
-              </style>
-            </div>
+            <div className="w-full my-8 giscus color-bg-canvas" />
             {router.isReady ? (
               <Head>
                 <script
@@ -118,7 +109,7 @@ export default function Home({ contentBefore, contentAfter }: HomeProps) {
                   data-term="Welcome to giscus!"
                   data-theme={directConfig.theme}
                   data-reactions-enabled={`${+directConfig.reactionsEnabled}`}
-                ></script>
+                />
               </Head>
             ) : null}
           </>


### PR DESCRIPTION
This PR adds a default `<style>` element to make giscus looks good out-of-box. The element will be added as the first child of `<head>` to make overriding possible.

Fixes #90.