### PR TITLE
Fix prerender crash if getAppAccessToken fails

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -18,7 +18,7 @@ export const getStaticProps = async () => {
   const contents = readme.split('<!-- configuration -->');
   contents[1] = `${contents[1]}\n## try it out 👇👇👇\n`;
 
-  const token = await getAppAccessToken('laymonage/giscus');
+  const token = await getAppAccessToken('laymonage/giscus').catch(() => '');
   const [contentBefore, contentAfter] = await Promise.all(
     contents.map(async (section) => await renderMarkdown(section, token, 'laymonage/giscus')),
   );


### PR DESCRIPTION
This may happen the app isn't installed on laymonage/giscus (because it's self-hosted).