### PR TITLE
Add option to also filter by category

### DIFF
--- a/client.ts
+++ b/client.ts
@@ -51,6 +51,7 @@ params.theme = attributes.theme;
 params.reactionsEnabled = attributes.reactionsEnabled || '1';
 params.repo = attributes.repo;
 params.repoId = attributes.repoId;
+params.category = attributes.category || '';
 params.categoryId = attributes.categoryId;
 params.description = ogDescriptionMeta ? ogDescriptionMeta.content : '';
 

--- a/components/CommentBox.tsx
+++ b/components/CommentBox.tsx
@@ -1,7 +1,7 @@
 import { MarkdownIcon } from '@primer/octicons-react';
 import { ChangeEvent, useCallback, useContext, useEffect, useState } from 'react';
 import { adaptComment, adaptReply, handleCommentClick, processCommentBody } from '../lib/adapter';
-import { AuthContext, getLoginUrl } from '../lib/context';
+import { AuthContext } from '../lib/context';
 import { IComment, IReply, IUser } from '../lib/types/adapter';
 import { resizeTextArea } from '../lib/utils';
 import { addDiscussionComment } from '../services/github/addDiscussionComment';
@@ -34,7 +34,7 @@ export default function CommentBox({
   const [isLoading, setIsLoading] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isReplyOpen, setIsReplyOpen] = useState(false);
-  const { token, origin } = useContext(AuthContext);
+  const { token, origin, getLoginUrl } = useContext(AuthContext);
   const loginUrl = getLoginUrl(origin);
   const isReply = !!replyToId;
 

--- a/components/Configuration.tsx
+++ b/components/Configuration.tsx
@@ -105,7 +105,9 @@ interface ConfigurationProps {
 export default function Configuration({ directConfig, onDirectConfigChange }: ConfigurationProps) {
   const [repository, setRepository] = useState('');
   const [repositoryId, setRepositoryId] = useState('');
+  const [category, setCategory] = useState('');
   const [categoryId, setCategoryId] = useState('');
+  const [useCategory, setUseCategory] = useState(true);
   const [error, setError] = useState(false);
   const [categories, setCategories] = useState<ICategory[]>([]);
   const [mapping, setMapping] = useState('pathname');
@@ -116,6 +118,7 @@ export default function Configuration({ directConfig, onDirectConfigChange }: Co
     setError(false);
     setRepositoryId('');
     setCategoryId('');
+    setCategory('');
     setCategories([]);
     if (dRepository) {
       getCategories(dRepository)
@@ -238,17 +241,16 @@ export default function Configuration({ directConfig, onDirectConfigChange }: Co
       </fieldset>
 
       <h3>Discussion Category</h3>
-      <p>
-        Choose the discussion category where new discussions will be created. This is only used for
-        discussion creation and <strong>does not</strong> affect how giscus searches for
-        discussions.
-      </p>
+      <p>Choose the discussion category where new discussions will be created.</p>
       <select
         name="category"
         id="category"
         disabled={!categories.length}
         value={categoryId}
-        onChange={(event) => setCategoryId(event.target.value)}
+        onChange={(event) => {
+          setCategoryId(event.target.value);
+          setCategory(event.target.selectedOptions[0]?.textContent.substr(3));
+        }}
         className={`px-[12px] py-[5px] pr-6 min-w-[200px] border rounded-md appearance-none bg-no-repeat form-control form-select color-border-primary color-bg-primary${
           !categoryId ? ' color-text-secondary' : ''
         }`}
@@ -262,6 +264,23 @@ export default function Configuration({ directConfig, onDirectConfigChange }: Co
           </option>
         ))}
       </select>
+      {mapping !== 'number' ? (
+        <div className="form-checkbox">
+          <input
+            type="checkbox"
+            id="useCategory"
+            checked={useCategory}
+            value={category}
+            onChange={(event) => setUseCategory(event.target.checked)}
+          ></input>
+          <label htmlFor="useCategory">
+            <strong>Only search for discussions in this category</strong>
+          </label>
+          <p className="mb-0 text-xs color-text-secondary">
+            When searching for a matching discussion, giscus will only search in this category.
+          </p>
+        </div>
+      ) : null}
 
       <h3>Features</h3>
       <p>Choose whether specific features should be enabled.</p>
@@ -325,6 +344,13 @@ export default function Configuration({ directConfig, onDirectConfigChange }: Co
           <span className="pl-c1">data-repo-id</span>={'"'}
           <span className="pl-s">{repositoryId || '[ENTER REPO ID HERE]'}</span>
           {'"\n        '}
+          {useCategory ? (
+            <>
+              <span className="pl-c1">data-category</span>={'"'}
+              <span className="pl-s">{category || '[ENTER CATEGORY NAME HERE]'}</span>
+              {'"\n        '}
+            </>
+          ) : null}
           <span className="pl-c1">data-category-id</span>={'"'}
           <span className="pl-s">{categoryId || '[ENTER CATEGORY ID HERE]'}</span>
           {'"\n        '}

--- a/components/Configuration.tsx
+++ b/components/Configuration.tsx
@@ -276,7 +276,7 @@ export default function Configuration({ directConfig, onDirectConfigChange }: IC
         onChange={(event) =>
           setConfig((current) => ({
             ...current,
-            category: event.target.selectedOptions[0]?.textContent.substr(3),
+            category: event.target.selectedOptions[0]?.dataset.category,
             categoryId: event.target.value,
           }))
         }
@@ -284,11 +284,11 @@ export default function Configuration({ directConfig, onDirectConfigChange }: IC
           !config.categoryId ? ' color-text-secondary' : ''
         }`}
       >
-        <option value="" disabled selected={!config.categoryId}>
+        <option value="" disabled selected={!config.categoryId} data-category="">
           {categories.length ? 'Pick a category' : 'No categories found'}
         </option>
         {categories.map(({ id, emoji, name }) => (
-          <option key={id} value={id} className="color-text-primary">
+          <option key={id} value={id} className="color-text-primary" data-category={name}>
             {emoji} {name}
           </option>
         ))}

--- a/components/Configuration.tsx
+++ b/components/Configuration.tsx
@@ -200,32 +200,6 @@ export default function Configuration({ directConfig, onDirectConfigChange }: Co
         )}
       </fieldset>
 
-      <h3>Discussion Category</h3>
-      <p>
-        Choose the discussion category where new discussions will be created. This is only used for
-        discussion creation and <strong>does not</strong> affect how giscus searches for
-        discussions.
-      </p>
-      <select
-        name="category"
-        id="category"
-        disabled={!categories.length}
-        value={categoryId}
-        onChange={(event) => setCategoryId(event.target.value)}
-        className={`px-[12px] py-[5px] pr-6 min-w-[200px] border rounded-md appearance-none bg-no-repeat form-control form-select color-border-primary color-bg-primary${
-          !categoryId ? ' color-text-secondary' : ''
-        }`}
-      >
-        <option value="" disabled selected={!categoryId}>
-          {categories.length ? 'Pick a category' : 'No categories found'}
-        </option>
-        {categories.map(({ id, emoji, name }) => (
-          <option key={id} value={id} className="color-text-primary">
-            {emoji} {name}
-          </option>
-        ))}
-      </select>
-
       <h3>Page ↔️ Discussions Mapping</h3>
       <p>Choose the mapping between the embedding page and the embedded discussion.</p>
       <fieldset>
@@ -262,6 +236,32 @@ export default function Configuration({ directConfig, onDirectConfigChange }: Co
           </div>
         ))}
       </fieldset>
+
+      <h3>Discussion Category</h3>
+      <p>
+        Choose the discussion category where new discussions will be created. This is only used for
+        discussion creation and <strong>does not</strong> affect how giscus searches for
+        discussions.
+      </p>
+      <select
+        name="category"
+        id="category"
+        disabled={!categories.length}
+        value={categoryId}
+        onChange={(event) => setCategoryId(event.target.value)}
+        className={`px-[12px] py-[5px] pr-6 min-w-[200px] border rounded-md appearance-none bg-no-repeat form-control form-select color-border-primary color-bg-primary${
+          !categoryId ? ' color-text-secondary' : ''
+        }`}
+      >
+        <option value="" disabled selected={!categoryId}>
+          {categories.length ? 'Pick a category' : 'No categories found'}
+        </option>
+        {categories.map(({ id, emoji, name }) => (
+          <option key={id} value={id} className="color-text-primary">
+            {emoji} {name}
+          </option>
+        ))}
+      </select>
 
       <h3>Features</h3>
       <p>Choose whether specific features should be enabled.</p>

--- a/components/Configuration.tsx
+++ b/components/Configuration.tsx
@@ -267,11 +267,24 @@ export default function Configuration({ directConfig, onDirectConfigChange }: IC
       </fieldset>
 
       <h3>Discussion Category</h3>
-      <p>Choose the discussion category where new discussions will be created.</p>
+      <p>
+        Choose the discussion category where new discussions will be created.{' '}
+        {config.mapping === 'number' ? (
+          <>
+            This feature is not supported if you use the <strong>specific discussion number</strong>{' '}
+            mapping.
+          </>
+        ) : (
+          <>
+            It is recommended to use a category with the <strong>Announcements</strong> type so that
+            new discussions can only be created by maintainers and giscus.
+          </>
+        )}
+      </p>
       <select
         name="category"
         id="category"
-        disabled={!categories.length}
+        disabled={!categories.length || config.mapping === 'number'}
         value={config.categoryId}
         onChange={(event) =>
           setConfig((current) => ({
@@ -285,7 +298,11 @@ export default function Configuration({ directConfig, onDirectConfigChange }: IC
         }`}
       >
         <option value="" disabled selected={!config.categoryId} data-category="">
-          {categories.length ? 'Pick a category' : 'No categories found'}
+          {config.mapping === 'number'
+            ? 'Not supported'
+            : categories.length
+            ? 'Pick a category'
+            : 'No categories found'}
         </option>
         {categories.map(({ id, emoji, name }) => (
           <option key={id} value={id} className="color-text-primary" data-category={name}>
@@ -293,25 +310,24 @@ export default function Configuration({ directConfig, onDirectConfigChange }: IC
           </option>
         ))}
       </select>
-      {config.mapping !== 'number' ? (
-        <div className="form-checkbox">
-          <input
-            type="checkbox"
-            id="useCategory"
-            checked={config.useCategory}
-            value={config.category}
-            onChange={(event) =>
-              setConfig((current) => ({ ...current, useCategory: event.target.checked }))
-            }
-          ></input>
-          <label htmlFor="useCategory">
-            <strong>Only search for discussions in this category</strong>
-          </label>
-          <p className="mb-0 text-xs color-text-secondary">
-            When searching for a matching discussion, giscus will only search in this category.
-          </p>
-        </div>
-      ) : null}
+      <div className="form-checkbox">
+        <input
+          disabled={config.mapping === 'number'}
+          type="checkbox"
+          id="useCategory"
+          checked={config.useCategory}
+          value={config.category}
+          onChange={(event) =>
+            setConfig((current) => ({ ...current, useCategory: event.target.checked }))
+          }
+        ></input>
+        <label htmlFor="useCategory">
+          <strong>Only search for discussions in this category</strong>
+        </label>
+        <p className="mb-0 text-xs color-text-secondary">
+          When searching for a matching discussion, giscus will only search in this category.
+        </p>
+      </div>
 
       <h3>Features</h3>
       <p>Choose whether specific features should be enabled.</p>
@@ -375,23 +391,29 @@ export default function Configuration({ directConfig, onDirectConfigChange }: IC
           <span className="pl-c1">data-repo-id</span>={'"'}
           <span className="pl-s">{config.repositoryId || '[ENTER REPO ID HERE]'}</span>
           {'"\n        '}
-          {config.useCategory ? (
+          {config.mapping !== 'number' ? (
             <>
-              <span className="pl-c1">data-category</span>={'"'}
-              <span className="pl-s">{config.category || '[ENTER CATEGORY NAME HERE]'}</span>
+              {config.useCategory ? (
+                <>
+                  <span className="pl-c1">data-category</span>={'"'}
+                  <span className="pl-s">{config.category || '[ENTER CATEGORY NAME HERE]'}</span>
+                  {'"\n        '}
+                </>
+              ) : null}
+              <span className="pl-c1">data-category-id</span>={'"'}
+              <span className="pl-s">{config.categoryId || '[ENTER CATEGORY ID HERE]'}</span>
               {'"\n        '}
             </>
           ) : null}
-          <span className="pl-c1">data-category-id</span>={'"'}
-          <span className="pl-s">{config.categoryId || '[ENTER CATEGORY ID HERE]'}</span>
-          {'"\n        '}
           <span className="pl-c1">data-mapping</span>={'"'}
           <span className="pl-s">{config.mapping}</span>
           {'"\n        '}
           {['specific', 'number'].includes(config.mapping) ? (
             <>
               <span className="pl-c1">data-term</span>={'"'}
-              <span className="pl-s">{config.term || '[ENTER TERM HERE]'}</span>
+              <span className="pl-s">
+                {config.term || `[ENTER ${config.mapping === 'number' ? 'NUMBER' : 'TERM'} HERE]`}
+              </span>
               {'"\n        '}
             </>
           ) : null}

--- a/components/Giscus.tsx
+++ b/components/Giscus.tsx
@@ -13,8 +13,8 @@ interface IGiscusProps {
 
 export default function Giscus({ onDiscussionCreateRequest, onError }: IGiscusProps) {
   const { token } = useContext(AuthContext);
-  const { repo, term, number, reactionsEnabled } = useContext(ConfigContext);
-  const query = { repo, term, number };
+  const { repo, term, number, category, reactionsEnabled } = useContext(ConfigContext);
+  const query = { repo, term, category, number };
 
   const backComments = useDiscussions(query, token, { last: 15 });
   const {

--- a/components/Giscus.tsx
+++ b/components/Giscus.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useContext } from 'react';
-import { AuthContext } from '../lib/context';
+import { AuthContext, ConfigContext } from '../lib/context';
 import { Reactions, updateDiscussionReaction } from '../lib/reactions';
 import { useDiscussions } from '../services/giscus/discussions';
 import Comment from './Comment';
@@ -7,23 +7,13 @@ import CommentBox from './CommentBox';
 import ReactButtons from './ReactButtons';
 
 interface IGiscusProps {
-  repo: string;
-  term?: string;
-  number?: number;
-  reactionsEnabled: boolean;
   onDiscussionCreateRequest?: () => Promise<string>;
   onError?: (message: string) => void;
 }
 
-export default function Giscus({
-  repo,
-  term,
-  number,
-  reactionsEnabled,
-  onDiscussionCreateRequest,
-  onError,
-}: IGiscusProps) {
+export default function Giscus({ onDiscussionCreateRequest, onError }: IGiscusProps) {
   const { token } = useContext(AuthContext);
+  const { repo, term, number, reactionsEnabled } = useContext(ConfigContext);
   const query = { repo, term, number };
 
   const backComments = useDiscussions(query, token, { last: 15 });

--- a/components/ReactButtons.tsx
+++ b/components/ReactButtons.tsx
@@ -1,6 +1,6 @@
 import { SmileyIcon } from '@primer/octicons-react';
 import { useCallback, useContext, useState } from 'react';
-import { AuthContext, getLoginUrl } from '../lib/context';
+import { AuthContext } from '../lib/context';
 import { useComponentVisible } from '../lib/hooks';
 import { IReactionGroups } from '../lib/types/adapter';
 import { Reactions } from '../lib/reactions';
@@ -47,7 +47,7 @@ export default function ReactButtons({
   const [current, setCurrent] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [ref, isOpen, setIsOpen] = useComponentVisible<HTMLDivElement>(false);
-  const { token, origin } = useContext(AuthContext);
+  const { token, origin, getLoginUrl } = useContext(AuthContext);
   const loginUrl = getLoginUrl(origin);
 
   const togglePopover = useCallback(() => setIsOpen(!isOpen), [isOpen, setIsOpen]);

--- a/components/Widget.tsx
+++ b/components/Widget.tsx
@@ -1,49 +1,34 @@
-import { NextRouter, useRouter } from 'next/router';
 import { useCallback, useState } from 'react';
 import Giscus from '../components/Giscus';
 import { AuthContext, getLoginUrl } from '../lib/context';
-import { useIsMounted } from '../lib/hooks';
 import { createDiscussion } from '../services/giscus/createDiscussion';
 import { getToken } from '../services/giscus/token';
 
 interface IWidgetProps {
+  origin: string;
+  session: string;
   repo: string;
-  term?: string;
-  number?: number;
+  term: string;
+  number: number;
   repoId: string;
   categoryId: string;
-  description?: string;
-  reactionsEnabled?: boolean;
-}
-
-function getSession(router: NextRouter) {
-  const session = router.query.session as string;
-  if (session) {
-    const query = { ...router.query };
-    delete query.session;
-    const url = { pathname: router.pathname, query };
-    const options = { scroll: false, shallow: true };
-    router.replace(url, undefined, options);
-  }
-  return session || '';
+  description: string;
+  reactionsEnabled: boolean;
 }
 
 export default function Widget({
+  origin,
+  session,
   repo,
   term,
   number,
   repoId,
   categoryId,
   description,
-  reactionsEnabled = true,
+  reactionsEnabled,
 }: IWidgetProps) {
-  const router = useRouter();
-  const isMounted = useIsMounted();
   const [token, setToken] = useState('');
   const [isFetchingToken, setIsFetchingToken] = useState(false);
-
-  const session = getSession(router);
-  const origin = (router.query.origin as string) || (isMounted ? location.href : '');
 
   const handleDiscussionCreateRequest = async () =>
     createDiscussion(repo, {
@@ -70,8 +55,7 @@ export default function Widget({
       .catch((err) => handleError(err?.message));
   }
 
-  const ready =
-    router.isReady && (!session || token) && !isFetchingToken && repo && (term || number);
+  const ready = (!session || token) && !isFetchingToken && repo && (term || number);
 
   return ready ? (
     <AuthContext.Provider value={{ token, origin, getLoginUrl }}>

--- a/components/Widget.tsx
+++ b/components/Widget.tsx
@@ -1,7 +1,7 @@
 import { NextRouter, useRouter } from 'next/router';
 import { useCallback, useState } from 'react';
 import Giscus from '../components/Giscus';
-import { AuthContext } from '../lib/context';
+import { AuthContext, getLoginUrl } from '../lib/context';
 import { useIsMounted } from '../lib/hooks';
 import { createDiscussion } from '../services/giscus/createDiscussion';
 import { getToken } from '../services/giscus/token';
@@ -74,7 +74,7 @@ export default function Widget({
     router.isReady && (!session || token) && !isFetchingToken && repo && (term || number);
 
   return ready ? (
-    <AuthContext.Provider value={{ token, origin }}>
+    <AuthContext.Provider value={{ token, origin, getLoginUrl }}>
       <Giscus
         repo={repo}
         term={term}

--- a/components/Widget.tsx
+++ b/components/Widget.tsx
@@ -10,6 +10,7 @@ interface IWidgetProps {
   repo: string;
   term: string;
   number: number;
+  category: string;
   repoId: string;
   categoryId: string;
   description: string;
@@ -22,6 +23,7 @@ export default function Widget({
   repo,
   term,
   number,
+  category,
   repoId,
   categoryId,
   description,
@@ -59,7 +61,7 @@ export default function Widget({
 
   return ready ? (
     <AuthContext.Provider value={{ token, origin, getLoginUrl }}>
-      <ConfigContext.Provider value={{ repo, term, number, reactionsEnabled }}>
+      <ConfigContext.Provider value={{ repo, term, number, category, reactionsEnabled }}>
         <Giscus onDiscussionCreateRequest={handleDiscussionCreateRequest} onError={handleError} />
       </ConfigContext.Provider>
     </AuthContext.Provider>

--- a/components/Widget.tsx
+++ b/components/Widget.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useState } from 'react';
 import Giscus from '../components/Giscus';
-import { AuthContext, getLoginUrl } from '../lib/context';
+import { AuthContext, ConfigContext, getLoginUrl } from '../lib/context';
 import { createDiscussion } from '../services/giscus/createDiscussion';
 import { getToken } from '../services/giscus/token';
 
@@ -59,14 +59,9 @@ export default function Widget({
 
   return ready ? (
     <AuthContext.Provider value={{ token, origin, getLoginUrl }}>
-      <Giscus
-        repo={repo}
-        term={term}
-        number={number}
-        reactionsEnabled={reactionsEnabled}
-        onDiscussionCreateRequest={handleDiscussionCreateRequest}
-        onError={handleError}
-      />
+      <ConfigContext.Provider value={{ repo, term, number, reactionsEnabled }}>
+        <Giscus onDiscussionCreateRequest={handleDiscussionCreateRequest} onError={handleError} />
+      </ConfigContext.Provider>
     </AuthContext.Provider>
   ) : null;
 }

--- a/lib/context.ts
+++ b/lib/context.ts
@@ -29,6 +29,7 @@ interface IConfigContext {
   repo: string;
   term: string;
   number: number;
+  category: string;
   reactionsEnabled: boolean;
 }
 
@@ -36,5 +37,6 @@ export const ConfigContext = createContext<IConfigContext>({
   repo: '',
   term: '',
   number: 0,
+  category: '',
   reactionsEnabled: true,
 });

--- a/lib/context.ts
+++ b/lib/context.ts
@@ -1,6 +1,11 @@
 import { createContext } from 'react';
 
-export const AuthContext = createContext({
+interface IAuthContext {
+  token: string;
+  origin: string;
+}
+
+export const AuthContext = createContext<IAuthContext>({
   token: '',
   origin: '',
 });
@@ -9,9 +14,11 @@ export function getLoginUrl(origin: string) {
   return `/api/oauth/authorize?redirect_uri=${encodeURIComponent(origin)}`;
 }
 
-export const ThemeContext = createContext<{
+interface IThemeContext {
   theme: string;
   setTheme?: (theme: string) => void;
-}>({
+}
+
+export const ThemeContext = createContext<IThemeContext>({
   theme: '',
 });

--- a/lib/context.ts
+++ b/lib/context.ts
@@ -24,3 +24,17 @@ interface IThemeContext {
 export const ThemeContext = createContext<IThemeContext>({
   theme: '',
 });
+
+interface IConfigContext {
+  repo: string;
+  term: string;
+  number: number;
+  reactionsEnabled: boolean;
+}
+
+export const ConfigContext = createContext<IConfigContext>({
+  repo: '',
+  term: '',
+  number: 0,
+  reactionsEnabled: true,
+});

--- a/lib/context.ts
+++ b/lib/context.ts
@@ -3,16 +3,18 @@ import { createContext } from 'react';
 interface IAuthContext {
   token: string;
   origin: string;
+  getLoginUrl: (origin: string) => string;
+}
+
+export function getLoginUrl(origin: string) {
+  return `/api/oauth/authorize?redirect_uri=${encodeURIComponent(origin)}`;
 }
 
 export const AuthContext = createContext<IAuthContext>({
   token: '',
   origin: '',
+  getLoginUrl,
 });
-
-export function getLoginUrl(origin: string) {
-  return `/api/oauth/authorize?redirect_uri=${encodeURIComponent(origin)}`;
-}
 
 interface IThemeContext {
   theme: string;

--- a/lib/types/common.ts
+++ b/lib/types/common.ts
@@ -9,4 +9,5 @@ export interface DiscussionQuery {
   repo: string;
   term: string;
   number: number;
+  category: string;
 }

--- a/pages/api/discussions/index.ts
+++ b/pages/api/discussions/index.ts
@@ -11,6 +11,7 @@ async function get(req: NextApiRequest, res: NextApiResponse<IGiscussion | IErro
     repo: req.query.repo as string,
     term: req.query.term as string,
     number: +req.query.number,
+    category: req.query.category as string,
     first: +req.query.first,
     last: +req.query.last,
     after: req.query.after as string,

--- a/pages/widget.tsx
+++ b/pages/widget.tsx
@@ -1,12 +1,31 @@
 import Head from 'next/head';
-import { useRouter } from 'next/router';
+import { NextRouter, useRouter } from 'next/router';
 import { useContext } from 'react';
 import Widget from '../components/Widget';
 import { ThemeContext } from '../lib/context';
+import { useIsMounted } from '../lib/hooks';
 
-export default function Home() {
+function popSession(router: NextRouter) {
+  const session = router.query.session as string;
+  if (session) {
+    const query = { ...router.query };
+    delete query.session;
+    const url = { pathname: router.pathname, query };
+    const options = { scroll: false, shallow: true };
+    router.replace(url, undefined, options);
+  }
+  return session || '';
+}
+
+export default function WidgetPage() {
   const router = useRouter();
+  const isMounted = useIsMounted();
   const { theme } = useContext(ThemeContext);
+
+  if (!router.isReady) return null;
+
+  const origin = (router.query.origin as string) || (isMounted ? location.href : '');
+  const session = popSession(router);
 
   const repo = router.query.repo as string;
   const term = router.query.term as string;
@@ -24,6 +43,8 @@ export default function Home() {
 
       <main className="w-full mx-auto" data-theme={theme}>
         <Widget
+          origin={origin}
+          session={session}
           repo={repo}
           term={term}
           number={number}

--- a/pages/widget.tsx
+++ b/pages/widget.tsx
@@ -29,6 +29,7 @@ export default function WidgetPage() {
 
   const repo = router.query.repo as string;
   const term = router.query.term as string;
+  const category = router.query.category as string;
   const number = +router.query.number;
   const repoId = router.query.repoId as string;
   const categoryId = router.query.categoryId as string;
@@ -48,6 +49,7 @@ export default function WidgetPage() {
           repo={repo}
           term={term}
           number={number}
+          category={category}
           repoId={repoId}
           categoryId={categoryId}
           description={description}

--- a/services/github/getDiscussion.ts
+++ b/services/github/getDiscussion.ts
@@ -142,8 +142,9 @@ export async function getDiscussion(
   params: GetDiscussionParams,
   token: string,
 ): Promise<GetDiscussionResponse | GError> {
-  const { repo, term, number, ...pagination } = params;
-  const query = `repo:${repo} in:title ${term}`;
+  const { repo, term, number, category, ...pagination } = params;
+  const categoryQuery = category ? `category:${JSON.stringify(category)}` : '';
+  const query = `repo:${repo} ${categoryQuery} in:title ${term}`;
   const gql = GET_DISCUSSION_QUERY(number ? 'number' : 'term');
 
   return fetch(GITHUB_GRAPHQL_API_URL, {


### PR DESCRIPTION
This PR adds an option to also use the selected category in the discussion search query, meaning that giscus will only search in the specified category. As a result, we also need to pass the `category` name because we cannot use `categoryId` for querying.

Also includes major refactoring for how config is handled. I should've made a separate PR for that, but oh well!

- All handling of query params is now placed in `widget.tsx` (page component).
- The `Widget` component uses `ConfigContext.Provider` to provide config values down the tree.
- The `Configuration` component uses an object state to manage the configuration values.