### PR TITLE
Remove typo from privacy policy

### DIFF
--- a/PRIVACY-POLICY.md
+++ b/PRIVACY-POLICY.md
@@ -21,7 +21,6 @@ Topics:
 - [Changes to our privacy policy](#changes-to-our-privacy-policy)
 - [How to contact us](#how-to-contact-us)
 - [How to contact the appropriate authorities](#how-to-contact-the-appropriate-authorities)
-  rights?](#what-are-your-data-protection-rights)
 
 ## What data do we collect?
 


### PR DESCRIPTION
There is a typo on the privacy policy. This PR removes it.