### PR TITLE
Fix crash on categories with GitHub custom emojis

### DIFF
--- a/pages/api/discussions/categories.ts
+++ b/pages/api/discussions/categories.ts
@@ -41,7 +41,7 @@ export default async (req: NextApiRequest, res: NextApiResponse<ICategories | IE
     discussionCategories: { nodes },
   } = repository;
   const categories = nodes.map(({ emojiHTML, ...rest }) => ({
-    emoji: emojiHTML?.match(/">(.*?)<\/g-emoji/)[1] || '',
+    emoji: emojiHTML?.match(/">(.*?)<\/g-emoji/)?.[1] || '',
     ...rest,
   }));
 


### PR DESCRIPTION
GitHub has custom emojis:
:atom: :basecamp:  :basecampy: :bowtie: :electron: :feelsgood: :finnadie: :goberserk: :godmode: :hurtrealbad: :neckbeard: :octocat: :rage1: :rage2: :rage3: :rage4: :shipit: :suspect: :trollface:

which is rendered using `<img>` tag instead of `<g-emoji>`, so the regex won't match. We can't use `<img>` tags in `<option>`, so let's just render an empty string.