### PR TITLE
Limit functions memory usage to 256MB

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,7 @@
+{
+  "functions": {
+    "pages/**/*.js": {
+      "memory": 256
+    }
+  }
+}


### PR DESCRIPTION
To reduce our usage on Vercel, let's try limiting the memory of the serverless functions to 512MB (default is 1GB). If it's enough, we might try reducing it again later.