### PR TITLE
Add option to emit discussion metadata

### DIFF
--- a/client.ts
+++ b/client.ts
@@ -49,6 +49,7 @@ params.origin = location.href;
 params.session = session;
 params.theme = attributes.theme;
 params.reactionsEnabled = attributes.reactionsEnabled || '1';
+params.emitMetadata = attributes.emitMetadata || '0';
 params.repo = attributes.repo;
 params.repoId = attributes.repoId;
 params.category = attributes.category || '';

--- a/components/Configuration.tsx
+++ b/components/Configuration.tsx
@@ -10,6 +10,7 @@ interface IDirectConfig {
   theme: string;
   themeUrl: string;
   reactionsEnabled: boolean;
+  emitMetadata: boolean;
 }
 
 interface IConfigurationProps {
@@ -151,6 +152,19 @@ export default function Configuration({ directConfig, onDirectConfigChange }: IC
         });
     }
   }, [dRepository]);
+
+  useEffect(() => {
+    const handleMessage = (event: MessageEvent) => {
+      const { data } = event;
+      if (!(typeof data === 'object' && data?.giscus?.discussion)) return;
+      console.log(data);
+    };
+
+    if (directConfig.emitMetadata) {
+      window.addEventListener('message', handleMessage);
+    }
+    return () => window.removeEventListener('message', handleMessage);
+  }, [directConfig.emitMetadata]);
 
   return (
     <div className="p-4 pt-0 markdown">
@@ -347,6 +361,23 @@ export default function Configuration({ directConfig, onDirectConfigChange }: IC
           The reactions for the {`discussion's`} main post will be shown before the comments.
         </p>
       </div>
+      <div className="form-checkbox">
+        <input
+          type="checkbox"
+          id="emitMetadata"
+          checked={directConfig.emitMetadata}
+          value={`${+directConfig.emitMetadata}`}
+          onChange={(event) => onDirectConfigChange('emitMetadata', event.target.checked)}
+        ></input>
+        <label htmlFor="emitMetadata">
+          <strong>Emit discussion metadata</strong>
+        </label>
+        <p className="mb-0 text-xs color-text-secondary">
+          Discussion metadata will be sent using <code>window.postMessage()</code> and you can
+          listen to the updates using <code>window.addEventListener({`'message'`}, ...)</code>.
+          Enable this option and open your {`browser's`} console for demonstration.
+        </p>
+      </div>
 
       <h3>Theme</h3>
       <p>
@@ -441,6 +472,9 @@ export default function Configuration({ directConfig, onDirectConfigChange }: IC
           ) : null}
           <span className="pl-c1">data-reactions-enabled</span>={'"'}
           <span className="pl-s">{Number(directConfig.reactionsEnabled)}</span>
+          {'"\n        '}
+          <span className="pl-c1">data-emit-metadata</span>={'"'}
+          <span className="pl-s">{Number(directConfig.emitMetadata)}</span>
           {'"\n        '}
           <span className="pl-c1">data-theme</span>={'"'}
           <span className="pl-s">

--- a/components/Configuration.tsx
+++ b/components/Configuration.tsx
@@ -373,9 +373,16 @@ export default function Configuration({ directConfig, onDirectConfigChange }: IC
           <strong>Emit discussion metadata</strong>
         </label>
         <p className="mb-0 text-xs color-text-secondary">
-          Discussion metadata will be sent using <code>window.postMessage()</code> and you can
-          listen to the updates using <code>window.addEventListener({`'message'`}, ...)</code>.
-          Enable this option and open your {`browser's`} console for demonstration.
+          Discussion metadata will be sent periodically to the parent window. For demonstration,
+          enable this option and open your {`browser's`} console on this page. See{' '}
+          <a
+            href="https://github.com/laymonage/giscus/blob/main/ADVANCED-USAGE.md#imetadatamessage"
+            target="_blank"
+            rel="noreferrer noopener nofollow"
+          >
+            the documentation
+          </a>{' '}
+          for more details.
         </p>
       </div>
 

--- a/components/Giscus.tsx
+++ b/components/Giscus.tsx
@@ -97,9 +97,9 @@ export default function Giscus({ onDiscussionCreateRequest, onError }: IGiscusPr
         {shouldShowReplyCount ? (
           <>
             <h4 className="mr-2 font-semibold gsc-comments-count-separator">·</h4>
-            <h4 className="mr-2 gsc-replies-count">{`${
-              Number.isNaN(data.totalReplyCount) ? 0 : data.totalReplyCount
-            }${data.numHidden > 0 ? '+' : ''} repl${data.totalReplyCount !== 1 ? 'ies' : 'y'}`}</h4>
+            <h4 className="mr-2 gsc-replies-count">{`${data.totalReplyCount}${
+              data.numHidden > 0 ? '+' : ''
+            } repl${data.totalReplyCount !== 1 ? 'ies' : 'y'}`}</h4>
           </>
         ) : null}
         {shouldShowBranding ? (

--- a/components/Giscus.tsx
+++ b/components/Giscus.tsx
@@ -1,4 +1,4 @@
-import { useContext } from 'react';
+import { useContext, useEffect } from 'react';
 import { AuthContext, ConfigContext } from '../lib/context';
 import { useFrontBackDiscussion } from '../services/giscus/discussions';
 import Comment from './Comment';
@@ -23,9 +23,11 @@ export default function Giscus({ onDiscussionCreateRequest, onError }: IGiscusPr
     ...data
   } = useFrontBackDiscussion(query, token);
 
-  if (data.error && onError) {
-    onError(data.error?.message);
-  }
+  useEffect(() => {
+    if (data.error && onError) {
+      onError(data.error?.message);
+    }
+  }, [data.error, onError]);
 
   const handleDiscussionCreateRequest = async () => {
     const id = await onDiscussionCreateRequest();

--- a/components/Giscus.tsx
+++ b/components/Giscus.tsx
@@ -1,6 +1,7 @@
 import { useContext, useEffect } from 'react';
 import { AuthContext, ConfigContext } from '../lib/context';
 import { emitData } from '../lib/messages';
+import { IMetadataMessage } from '../lib/types/giscus';
 import { useFrontBackDiscussion } from '../services/giscus/discussions';
 import Comment from './Comment';
 import CommentBox from './CommentBox';
@@ -34,7 +35,11 @@ export default function Giscus({ onDiscussionCreateRequest, onError }: IGiscusPr
 
   useEffect(() => {
     if (!emitMetadata || !data.discussion.id) return;
-    emitData({ discussion: data.discussion, viewer: data.viewer }, origin);
+    const message: IMetadataMessage = {
+      discussion: data.discussion,
+      viewer: data.viewer,
+    };
+    emitData(message, origin);
   }, [data.discussion, data.viewer, emitMetadata, origin]);
 
   const handleDiscussionCreateRequest = async () => {

--- a/components/Widget.tsx
+++ b/components/Widget.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import Giscus from '../components/Giscus';
 import { AuthContext, ConfigContext, getLoginUrl } from '../lib/context';
+import { emitData } from '../lib/messages';
 import { createDiscussion } from '../services/giscus/createDiscussion';
 import { getToken } from '../services/giscus/token';
 
@@ -41,7 +42,7 @@ export default function Widget({
 
   const handleError = useCallback(
     (message: string) => {
-      window.parent.postMessage({ giscus: { error: message } }, origin);
+      emitData({ error: message }, origin);
     },
     [origin],
   );

--- a/components/Widget.tsx
+++ b/components/Widget.tsx
@@ -2,6 +2,7 @@ import { useCallback, useContext, useEffect, useState } from 'react';
 import Giscus from '../components/Giscus';
 import { AuthContext, ConfigContext, getLoginUrl } from '../lib/context';
 import { emitData } from '../lib/messages';
+import { IErrorMessage } from '../lib/types/giscus';
 import { createDiscussion } from '../services/giscus/createDiscussion';
 import { getToken } from '../services/giscus/token';
 
@@ -27,7 +28,7 @@ export default function Widget({ origin, session, repoId, categoryId, descriptio
 
   const handleError = useCallback(
     (message: string) => {
-      emitData({ error: message }, origin);
+      emitData<IErrorMessage>({ error: message }, origin);
     },
     [origin],
   );

--- a/components/Widget.tsx
+++ b/components/Widget.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useContext, useEffect, useState } from 'react';
 import Giscus from '../components/Giscus';
 import { AuthContext, ConfigContext, getLoginUrl } from '../lib/context';
 import { emitData } from '../lib/messages';
@@ -8,29 +8,14 @@ import { getToken } from '../services/giscus/token';
 interface IWidgetProps {
   origin: string;
   session: string;
-  repo: string;
-  term: string;
-  number: number;
-  category: string;
   repoId: string;
   categoryId: string;
   description: string;
-  reactionsEnabled: boolean;
 }
 
-export default function Widget({
-  origin,
-  session,
-  repo,
-  term,
-  number,
-  category,
-  repoId,
-  categoryId,
-  description,
-  reactionsEnabled,
-}: IWidgetProps) {
+export default function Widget({ origin, session, repoId, categoryId, description }: IWidgetProps) {
   const [token, setToken] = useState('');
+  const { repo, term, number } = useContext(ConfigContext);
 
   const handleDiscussionCreateRequest = async () =>
     createDiscussion(repo, {
@@ -59,9 +44,7 @@ export default function Widget({
 
   return ready ? (
     <AuthContext.Provider value={{ token, origin, getLoginUrl }}>
-      <ConfigContext.Provider value={{ repo, term, number, category, reactionsEnabled }}>
-        <Giscus onDiscussionCreateRequest={handleDiscussionCreateRequest} onError={handleError} />
-      </ConfigContext.Provider>
+      <Giscus onDiscussionCreateRequest={handleDiscussionCreateRequest} onError={handleError} />
     </AuthContext.Provider>
   ) : null;
 }

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -1,6 +1,6 @@
-import { RepoConfig } from './types/giscus';
+import { IRepoConfig } from './types/giscus';
 
-export function assertOrigin(origin: string, { origins = [], originsRegex = [] }: RepoConfig) {
+export function assertOrigin(origin: string, { origins = [], originsRegex = [] }: IRepoConfig) {
   if (!origins.length && !originsRegex.length) return true;
 
   for (let i = 0; i < origins.length; i++) {

--- a/lib/context.ts
+++ b/lib/context.ts
@@ -31,6 +31,7 @@ interface IConfigContext {
   number: number;
   category: string;
   reactionsEnabled: boolean;
+  emitMetadata: boolean;
 }
 
 export const ConfigContext = createContext<IConfigContext>({
@@ -39,4 +40,5 @@ export const ConfigContext = createContext<IConfigContext>({
   number: 0,
   category: '',
   reactionsEnabled: true,
+  emitMetadata: false,
 });

--- a/lib/messages.ts
+++ b/lib/messages.ts
@@ -1,0 +1,3 @@
+export function emitData<T>(data: T, origin: string) {
+  window.parent.postMessage({ giscus: data }, origin);
+}

--- a/lib/messages.ts
+++ b/lib/messages.ts
@@ -1,3 +1,5 @@
+import { IMessage } from './types/giscus';
+
 export function emitData<T>(data: T, origin: string) {
-  window.parent.postMessage({ giscus: data }, origin);
+  window.parent.postMessage({ giscus: data } as IMessage<T>, origin);
 }

--- a/lib/types/giscus.ts
+++ b/lib/types/giscus.ts
@@ -1,4 +1,4 @@
-import { IReactionGroups } from './adapter';
+import { IReactionGroups, IUser } from './adapter';
 
 export interface ITokenRequest {
   session: string;
@@ -24,4 +24,17 @@ export interface IDiscussionData {
   totalCommentCount: number;
   totalReplyCount: number;
   reactions: IReactionGroups;
+}
+
+export interface IMessage<T> {
+  giscus: T;
+}
+
+export interface IErrorMessage {
+  error: string;
+}
+
+export interface IMetadataMessage {
+  discussion: IDiscussionData;
+  viewer: IUser;
 }

--- a/lib/types/giscus.ts
+++ b/lib/types/giscus.ts
@@ -1,3 +1,5 @@
+import { IReactionGroups, IComment } from './adapter';
+
 export interface ITokenRequest {
   session: string;
 }
@@ -9,4 +11,19 @@ export interface ITokenResponse {
 export interface RepoConfig {
   origins?: string[];
   originsRegex?: string[];
+}
+
+export interface IDiscussionData {
+  id: string;
+  url: string;
+  locked: boolean;
+  repository: {
+    nameWithOwner: string;
+  };
+  reactionCount: number;
+  totalCommentCount: number;
+  totalReplyCount: number;
+  reactions: IReactionGroups;
+  frontComments: IComment[];
+  backComments: IComment[];
 }

--- a/lib/types/giscus.ts
+++ b/lib/types/giscus.ts
@@ -1,4 +1,4 @@
-import { IReactionGroups, IComment } from './adapter';
+import { IReactionGroups } from './adapter';
 
 export interface ITokenRequest {
   session: string;
@@ -24,6 +24,4 @@ export interface IDiscussionData {
   totalCommentCount: number;
   totalReplyCount: number;
   reactions: IReactionGroups;
-  frontComments: IComment[];
-  backComments: IComment[];
 }

--- a/lib/types/giscus.ts
+++ b/lib/types/giscus.ts
@@ -8,7 +8,7 @@ export interface ITokenResponse {
   token: string;
 }
 
-export interface RepoConfig {
+export interface IRepoConfig {
   origins?: string[];
   originsRegex?: string[];
 }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -45,6 +45,7 @@ export default function Home({ contentBefore, contentAfter }: HomeProps) {
     theme: 'light',
     themeUrl: '',
     reactionsEnabled: true,
+    emitMetadata: false,
   });
   const themeUrl = useDebounce(directConfig.themeUrl);
   const resolvedTheme = directConfig.theme === 'custom' ? themeUrl : directConfig.theme;
@@ -109,6 +110,7 @@ export default function Home({ contentBefore, contentAfter }: HomeProps) {
                 data-term="Welcome to giscus!"
                 data-theme={resolvedTheme}
                 data-reactions-enabled={`${+directConfig.reactionsEnabled}`}
+                data-emit-metadata={`${+directConfig.emitMetadata}`}
               />
             </Head>
           </>

--- a/pages/widget.tsx
+++ b/pages/widget.tsx
@@ -23,6 +23,7 @@ export async function getServerSideProps({ query }: GetServerSidePropsContext) {
   const categoryId = (query.categoryId as string) || '';
   const description = (query.description as string) || '';
   const reactionsEnabled = Boolean(+query.reactionsEnabled);
+  const emitMetadata = Boolean(+query.emitMetadata);
   const theme = (query.theme as string) || '';
   const originHost = getOriginHost(origin);
   let error: ErrorType = null;
@@ -49,6 +50,7 @@ export async function getServerSideProps({ query }: GetServerSidePropsContext) {
       categoryId,
       description,
       reactionsEnabled,
+      emitMetadata,
       theme,
       originHost,
       error,
@@ -67,6 +69,7 @@ export default function WidgetPage({
   categoryId,
   description,
   reactionsEnabled,
+  emitMetadata,
   theme,
   originHost,
   error,
@@ -94,7 +97,9 @@ export default function WidgetPage({
             .
           </div>
         ) : (
-          <ConfigContext.Provider value={{ repo, term, number, category, reactionsEnabled }}>
+          <ConfigContext.Provider
+            value={{ repo, term, number, category, reactionsEnabled, emitMetadata }}
+          >
             <Widget
               origin={resolvedOrigin}
               session={session}

--- a/pages/widget.tsx
+++ b/pages/widget.tsx
@@ -3,7 +3,7 @@ import Head from 'next/head';
 import { useContext, useEffect } from 'react';
 import Widget from '../components/Widget';
 import { assertOrigin } from '../lib/config';
-import { ThemeContext } from '../lib/context';
+import { ConfigContext, ThemeContext } from '../lib/context';
 import { decodeState } from '../lib/oauth/state';
 import { getOriginHost } from '../lib/utils';
 import { env } from '../lib/variables';
@@ -94,18 +94,15 @@ export default function WidgetPage({
             .
           </div>
         ) : (
-          <Widget
-            origin={resolvedOrigin}
-            session={session}
-            repo={repo}
-            term={term}
-            number={number}
-            category={category}
-            repoId={repoId}
-            categoryId={categoryId}
-            description={description}
-            reactionsEnabled={reactionsEnabled}
-          />
+          <ConfigContext.Provider value={{ repo, term, number, category, reactionsEnabled }}>
+            <Widget
+              origin={resolvedOrigin}
+              session={session}
+              repoId={repoId}
+              categoryId={categoryId}
+              description={description}
+            />
+          </ConfigContext.Provider>
         )}
       </main>
 

--- a/services/giscus/discussions.ts
+++ b/services/giscus/discussions.ts
@@ -252,8 +252,6 @@ export function useFrontBackDiscussion(query: DiscussionQuery, token?: string) {
     locked: backData?.discussion?.locked,
     reactions: backData?.discussion?.reactions,
     repository: backData?.discussion?.repository,
-    frontComments,
-    backComments,
     reactionCount,
     totalCommentCount,
     totalReplyCount,

--- a/services/giscus/discussions.ts
+++ b/services/giscus/discussions.ts
@@ -4,6 +4,7 @@ import { cleanParams, fetcher } from '../../lib/fetcher';
 import { Reactions, updateDiscussionReaction } from '../../lib/reactions';
 import { IComment, IGiscussion, IReply } from '../../lib/types/adapter';
 import { DiscussionQuery, PaginationParams } from '../../lib/types/common';
+import { IDiscussionData } from '../../lib/types/giscus';
 
 export function useDiscussion(
   query: DiscussionQuery,
@@ -245,7 +246,7 @@ export function useFrontBackDiscussion(query: DiscussionQuery, token?: string) {
   const isNotFound = error?.status === 404;
   const isLocked = backData?.discussion?.locked;
 
-  const discussion = {
+  const discussion: IDiscussionData = {
     id: backData?.discussion?.id,
     url: backData?.discussion?.url,
     locked: backData?.discussion?.locked,

--- a/services/giscus/discussions.ts
+++ b/services/giscus/discussions.ts
@@ -235,8 +235,8 @@ export function useFrontBackDiscussion(query: DiscussionQuery, token?: string) {
   const reactionCount = backData?.discussion?.reactionCount;
   const totalCommentCount = backData?.discussion?.totalCommentCount;
   const totalReplyCount =
-    backData?.discussion?.totalReplyCount +
-    frontData?.reduce((prev, g) => prev + g.discussion.totalReplyCount, 0);
+    (backData?.discussion?.totalReplyCount || 0) +
+    (frontData?.reduce((prev, g) => prev + g.discussion.totalReplyCount, 0) || 0);
 
   const error = frontError || backError;
   const needsFrontLoading = backData?.discussion?.pageInfo?.hasPreviousPage;

--- a/services/giscus/discussions.ts
+++ b/services/giscus/discussions.ts
@@ -1,10 +1,11 @@
 import { useCallback, useMemo, useState } from 'react';
 import { SWRConfig, useSWRInfinite } from 'swr';
 import { cleanParams, fetcher } from '../../lib/fetcher';
+import { Reactions, updateDiscussionReaction } from '../../lib/reactions';
 import { IComment, IGiscussion, IReply } from '../../lib/types/adapter';
 import { DiscussionQuery, PaginationParams } from '../../lib/types/common';
 
-export function useDiscussions(
+export function useDiscussion(
   query: DiscussionQuery,
   token?: string,
   pagination: PaginationParams = {},
@@ -158,5 +159,126 @@ export function useDiscussions(
       updateReply,
       mutate,
     },
+  };
+}
+
+export function useFrontBackDiscussion(query: DiscussionQuery, token?: string) {
+  const backDiscussion = useDiscussion(query, token, { last: 15 });
+  const {
+    data: _backData,
+    isLoading: isBackLoading,
+    mutators: backMutators,
+    error: backError,
+  } = backDiscussion;
+
+  const backData = _backData && _backData[_backData.length - 1];
+  const intersectId = backData?.discussion?.comments?.[0]?.id;
+
+  const frontDiscussion = useDiscussion(query, token, { first: 15 });
+  const {
+    data: _frontData,
+    isLoading: isFrontLoading,
+    mutators: frontMutators,
+    size,
+    setSize,
+    error: frontError,
+  } = frontDiscussion;
+
+  const frontData = _frontData?.map((page) => {
+    let foundIntersect = false;
+
+    // We couldn't make use of GitHub API's `before` parameter to prevent
+    // duplicates because that would change our key for SWR. Therefore,
+    // we need to get rid of duplicates manually by removing the comments
+    // that are already in backData.
+    const newData = {
+      ...page,
+      discussion: {
+        ...page?.discussion,
+        comments: page?.discussion?.comments?.filter((comment) => {
+          if (comment.id === intersectId) {
+            foundIntersect = true;
+          }
+          return foundIntersect ? false : true;
+        }),
+      },
+    };
+
+    // Fix the reply count.
+    newData.discussion.totalReplyCount = newData.discussion.comments?.reduce(
+      (prev, c) => prev + c.replyCount,
+      0,
+    );
+
+    return newData;
+  });
+
+  const backComments = backData?.discussion?.comments || [];
+  const frontComments = frontData?.flatMap((page) => page?.discussion?.comments || []) || [];
+
+  const updateReactions = useCallback(
+    (reaction: Reactions, promise: Promise<unknown>) =>
+      backData
+        ? backMutators.updateDiscussion([updateDiscussionReaction(backData, reaction)], promise)
+        : promise.then(() => backMutators.mutate()),
+    [backData, backMutators],
+  );
+
+  const increaseSize = useCallback(() => setSize(size + 1), [setSize, size]);
+
+  const numHidden =
+    backData?.discussion?.totalCommentCount -
+    backData?.discussion?.comments?.length -
+    frontData?.reduce((prev, g) => prev + g.discussion.comments?.length, 0);
+
+  const reactionCount = backData?.discussion?.reactionCount;
+  const totalCommentCount = backData?.discussion?.totalCommentCount;
+  const totalReplyCount =
+    backData?.discussion?.totalReplyCount +
+    frontData?.reduce((prev, g) => prev + g.discussion.totalReplyCount, 0);
+
+  const error = frontError || backError;
+  const needsFrontLoading = backData?.discussion?.pageInfo?.hasPreviousPage;
+
+  const isLoading = (needsFrontLoading && isFrontLoading) || isBackLoading;
+  const isLoadingMore = isFrontLoading || (size > 0 && !frontData?.[size - 1]);
+  const isNotFound = error?.status === 404;
+  const isLocked = backData?.discussion?.locked;
+
+  const discussion = {
+    id: backData?.discussion?.id,
+    url: backData?.discussion?.url,
+    locked: backData?.discussion?.locked,
+    reactions: backData?.discussion?.reactions,
+    repository: backData?.discussion?.repository,
+    frontComments,
+    backComments,
+    reactionCount,
+    totalCommentCount,
+    totalReplyCount,
+  };
+
+  const viewer = backData?.viewer;
+
+  return {
+    updateReactions,
+    increaseSize,
+    frontData,
+    frontComments,
+    frontMutators,
+    backData,
+    backComments,
+    backMutators,
+    numHidden,
+    reactionCount,
+    totalCommentCount,
+    totalReplyCount,
+    error,
+    isLoading,
+    isLoadingMore,
+    isNotFound,
+    isLocked,
+    discussion,
+    viewer,
   };
 }

--- a/services/github/getConfig.ts
+++ b/services/github/getConfig.ts
@@ -1,9 +1,9 @@
-import { RepoConfig } from '../../lib/types/giscus';
+import { IRepoConfig } from '../../lib/types/giscus';
 import { getJSONFile } from './getFile';
 
 export async function getRepoConfig(repoWithOwner: string, token?: string) {
   try {
-    return await getJSONFile<RepoConfig>(repoWithOwner, 'giscus.json', token);
+    return await getJSONFile<IRepoConfig>(repoWithOwner, 'giscus.json', token);
   } catch (err) {
     return {};
   }


### PR DESCRIPTION
Fix #114.

Discussion metadata interface:

```ts
export interface IDiscussionData {
  id: string;
  url: string;
  locked: boolean;
  repository: {
    nameWithOwner: string;
  };
  reactionCount: number;
  totalCommentCount: number;
  totalReplyCount: number;
  reactions: IReactionGroups;
}

export interface IUser {
  avatarUrl: string;
  login: string;
  url: string;
}

export interface IMessage<T> {
  giscus: T;
}

export interface IMetadataMessage {
  discussion: IDiscussionData;
  viewer: IUser;
}
```

The `event.data` of `MessageEvent` will be typed as `IMessage<IMetadataMessage>`, i.e.

```ts
function handleMessage(event: MessageEvent) {
  if (event.origin !== 'https://giscus.app') return;
  if (!(typeof event.data === 'object' && event.data.giscus)) return;

  const giscusData = event.data.giscus;

  // Make sure that the message is one that contains the discussion metadata.
  // This is necessary because other message types are also available.
  if ('discussion' in giscusData) {
    const discussion: IDiscussionData = giscusData.discussion;
    const viewer: IUser = giscusData.viewer;
    // Do whatever you want with it
  }
}

window.addEventListener('message', handleMessage);
```

This PR also includes major refactoring of the pagination handling logic by extracting it into the `useFrontBackDiscussion` hook.