### PR TITLE
Add support for updating config on-the-fly with `postMessage`

### DIFF
--- a/ADVANCED-USAGE.md
+++ b/ADVANCED-USAGE.md
@@ -141,7 +141,7 @@ interface IErrorMessage {
 }
 ```
 
-Following the above `handleMessage` example, that means `giscusData` will be of
+Following the `handleMessage` example above, that means `giscusData` will be of
 type `IErrorMessage`:
 
 ```ts
@@ -165,7 +165,7 @@ interface IMetadataMessage {
 }
 ```
 
-Following the above `handleMessage` example, that means `giscusData` will be of
+Following the `handleMessage` example above, that means `giscusData` will be of
 type `IMetadataMessage`:
 
 ```ts
@@ -174,6 +174,58 @@ if ('discussion' in giscusData) {
   console.log(metadataMessage.discussion);
   console.log(metadataMessage.viewer);
 }
+```
+
+## parent-to-giscus `message` events
+
+The `contentWindow` of giscus' `<iframe>` element also listens to `message`
+events. You can send these events to update giscus based on your page's state.
+For example:
+
+```ts
+function sendMessage<T>(message: T) {
+  const iframe = document.querySelector<HTMLIFrameElement>('iframe.giscus-frame');
+  if (!iframe) return;
+  iframe.contentWindow.postMessage({ giscus: message }, location.origin);
+}
+```
+
+The `T` type of the `message` in the above example can be any of the following
+interfaces. For more details of the interfaces, see
+[`lib/types/giscus.ts`][giscus.ts] and the interfaces imported inside that
+module.
+
+### `ISetConfigMessage`
+
+The `ISetConfigMessage` interface lets you change giscus' config on-the-fly
+without having to reload the `<script>` or `<iframe>` elements. All of the
+properties inside the `setConfig` property are optional, which means that
+you can update a specific subset of the config and leave everything else as-is.
+
+```ts
+interface ISetConfigMessage {
+  setConfig: {
+    theme?: string;
+    repo?: string;
+    term?: string;
+    number?: number;
+    category?: string;
+    reactionsEnabled?: boolean;
+    emitMetadata?: boolean;
+  };
+}
+```
+
+Following the `sendMessage` example above, that means `message` will be of
+type `IMetadataMessage`:
+
+```ts
+sendMessage({
+  setConfig: {
+    theme: 'https://giscus.app/themes/custom_example.css',
+    reactionsEnabled: false,
+  }
+});
 ```
 
 [giscus.json]: giscus.json

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A comments system powered by [GitHub Discussions][discussions]. Let visitors lea
 - No tracking, no ads, always free. 📡 🚫
 - No database needed. All data is stored in GitHub Discussions. :octocat:
 - Supports [custom themes][creating-custom-themes]! 🌗
+- [Extensively configurable][advanced-usage]. 🔧
 - Automatically fetches new comments and edits from GitHub. 🔃
 - [Can be self-hosted][self-hosting]! 🤳
 
@@ -22,6 +23,7 @@ To comment, visitors must authorize the [giscus app][giscus-app] to [post on the
 [discussions]: https://docs.github.com/en/discussions
 [utterances]: https://github.com/utterance/utterances
 [repo]: https://github.com/laymonage/giscus
+[advanced-usage]: https://github.com/laymonage/giscus/blob/main/ADVANCED-USAGE.md
 [creating-custom-themes]: https://github.com/laymonage/giscus/blob/main/ADVANCED-USAGE.md#data-theme
 [self-hosting]: https://github.com/laymonage/giscus/blob/main/SELF-HOSTING.md
 [search-api]: https://docs.github.com/en/graphql/guides/using-the-graphql-api-for-discussions#search

--- a/lib/messages.ts
+++ b/lib/messages.ts
@@ -3,3 +3,9 @@ import { IMessage } from './types/giscus';
 export function emitData<T>(data: T, origin: string) {
   window.parent.postMessage({ giscus: data } as IMessage<T>, origin);
 }
+
+export function sendData<T>(data: T, origin: string) {
+  const iframe = document.querySelector<HTMLIFrameElement>('iframe.giscus-frame');
+  if (!iframe) return;
+  iframe.contentWindow.postMessage({ giscus: data } as IMessage<T>, origin);
+}

--- a/lib/types/giscus.ts
+++ b/lib/types/giscus.ts
@@ -30,6 +30,7 @@ export interface IMessage<T> {
   giscus: T;
 }
 
+// giscus-to-parent messages
 export interface IErrorMessage {
   error: string;
 }
@@ -37,4 +38,17 @@ export interface IErrorMessage {
 export interface IMetadataMessage {
   discussion: IDiscussionData;
   viewer: IUser;
+}
+
+// parent-to-giscus messages
+export interface ISetConfigMessage {
+  setConfig: {
+    theme?: string;
+    repo?: string;
+    term?: string;
+    number?: number;
+    category?: string;
+    reactionsEnabled?: boolean;
+    emitMetadata?: boolean;
+  };
 }

--- a/pages/widget.tsx
+++ b/pages/widget.tsx
@@ -1,10 +1,11 @@
 import { GetServerSidePropsContext, InferGetServerSidePropsType } from 'next';
 import Head from 'next/head';
-import { useContext, useEffect } from 'react';
+import { ContextType, useContext, useEffect, useState } from 'react';
 import Widget from '../components/Widget';
 import { assertOrigin } from '../lib/config';
 import { ConfigContext, ThemeContext } from '../lib/context';
 import { decodeState } from '../lib/oauth/state';
+import { ISetConfigMessage } from '../lib/types/giscus';
 import { getOriginHost } from '../lib/utils';
 import { env } from '../lib/variables';
 import { getAppAccessToken } from '../services/github/getAppAccessToken';
@@ -70,14 +71,42 @@ export default function WidgetPage({
   description,
   reactionsEnabled,
   emitMetadata,
-  theme,
   originHost,
   error,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const resolvedOrigin = origin || (typeof location === 'undefined' ? '' : location.href);
   const { theme: resolvedTheme, setTheme } = useContext(ThemeContext);
+  const [config, setConfig] = useState<ContextType<typeof ConfigContext>>({
+    repo,
+    term,
+    number,
+    category,
+    reactionsEnabled,
+    emitMetadata,
+  });
 
-  useEffect(() => setTheme(theme), [setTheme, theme]);
+  useEffect(() => {
+    const handleMessage = (event: MessageEvent) => {
+      if (event.origin !== originHost) return;
+      if (typeof event.data !== 'object' || !event.data.giscus) return;
+
+      const giscusData = event.data.giscus;
+
+      if ('setConfig' in giscusData) {
+        const { setConfig: newConfig } = giscusData as ISetConfigMessage;
+
+        if ('theme' in newConfig) {
+          setTheme(newConfig.theme);
+          delete newConfig.theme;
+        }
+
+        setConfig((prevConfig) => ({ ...prevConfig, ...newConfig }));
+      }
+    };
+
+    window.addEventListener('message', handleMessage);
+    return () => window.removeEventListener('message', handleMessage);
+  }, [originHost, setTheme]);
 
   return (
     <>
@@ -97,9 +126,7 @@ export default function WidgetPage({
             .
           </div>
         ) : (
-          <ConfigContext.Provider
-            value={{ repo, term, number, category, reactionsEnabled, emitMetadata }}
-          >
+          <ConfigContext.Provider value={config}>
             <Widget
               origin={resolvedOrigin}
               session={session}


### PR DESCRIPTION
Fix #134.

This PR adds support for updating giscus config on-the-fly with `iframe.contentWindow.postMessage`.

Example usage:

```ts
interface ISetConfigMessage {
  setConfig: {
    theme?: string;
    repo?: string;
    term?: string;
    number?: number;
    category?: string;
    reactionsEnabled?: boolean;
    emitMetadata?: boolean;
  };
}

function sendMessage<T>(message: T) {
  const iframe = document.querySelector<HTMLIFrameElement>('iframe.giscus-frame');
  if (!iframe) return;
  iframe.contentWindow.postMessage({ giscus: message }, location.origin);
}

sendMessage({
  setConfig: {
    theme: 'https://giscus.app/themes/custom_example.css',
    reactionsEnabled: false,
  }
} as ISetConfigMessage);
```