### PR TITLE
Fix `sendMessage` example

### DIFF
--- a/ADVANCED-USAGE.md
+++ b/ADVANCED-USAGE.md
@@ -188,7 +188,7 @@ For example:
 function sendMessage<T>(message: T) {
   const iframe = document.querySelector<HTMLIFrameElement>('iframe.giscus-frame');
   if (!iframe) return;
-  iframe.contentWindow.postMessage({ giscus: message }, location.origin);
+  iframe.contentWindow.postMessage({ giscus: message }, 'https://giscus.app');
 }
 ```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ major updates to the project.
 - Minor fixes ([#137](https://github.com/laymonage/giscus/pull/137)).
 - Fix unchanged theme on initial load
   ([#140](https://github.com/laymonage/giscus/pull/140)).
+- Fix `sendMessage` example
+  ([#141](https://github.com/laymonage/giscus/pull/141)).
 
 ## 2021-07-10
 


### PR DESCRIPTION
It should be `targetOrigin` (i.e. https://giscus.app), see [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage#syntax).