### PR TITLE
Add security headers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,7 @@ GITHUB_CLIENT_ID=Iv1.abcd1234wxyz5678
 GITHUB_CLIENT_SECRET=abcd1234wxyz5678abcd1234wxyz5678abcd1234
 GITHUB_PRIVATE_KEY="-----BEGIN RSA PRIVATE KEY-----\nENTER-KEY-HERE-WITHOUT-LINE-BREAKS\n-----END RSA PRIVATE KEY-----"
 ENCRYPTION_PASSWORD=s0m3r4nd0mstr1ng!w1thh1gh3ntr0pys0m3r4nd0mstr1ngw1thh1gh3ntr0py!
+# The following values are only for CORS-related stuff in the API.
+# The usage is different from the values in giscus.json.
+ORIGINS=["https://giscus.app", "https://giscus.vercel.app"]
+ORIGINS_REGEX=["http://localhost:[0-9]+"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,19 @@ major updates to the project.
 
 ## 2021-07-25
 
+### added
+
+- Add security headers ([#147](https://github.com/laymonage/giscus/pull/147)).
+
 ### changed
 
 - Use media query in CSS for `preferred_color_scheme` theme
   ([#146](https://github.com/laymonage/giscus/pull/146)).
+- The "origin not allowed" error message implemented in
+  [#125](https://github.com/laymonage/giscus/pull/125) is no longer shown.
+  Instead, the browser will now refuse to load the `iframe` as a result of
+  the `frame-ancestors` value in the `Content-Security-Policy` header
+  ([#147](https://github.com/laymonage/giscus/pull/147)).
 
 ## 2021-07-12
 

--- a/SELF-HOSTING.md
+++ b/SELF-HOSTING.md
@@ -181,6 +181,8 @@ functions.
   GITHUB_PRIVATE_KEY="-----BEGIN RSA PRIVATE KEY-----\nENTER-KEY-HERE-WITHOUT-LINE-BREAKS\n-----END RSA PRIVATE
   KEY-----"
   ENCRYPTION_PASSWORD=s0m3r4nd0mstr1ngw1thh1gh3ntr0py
+  ORIGINS=["https://giscus.app", "https://giscus.vercel.app"]
+  ORIGINS_REGEX=["http://localhost:[0-9]+"]
   ```
 
 - Install the dependencies.

--- a/lib/cors.ts
+++ b/lib/cors.ts
@@ -1,0 +1,16 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+import { assertOrigin } from './config';
+import { env } from './variables';
+
+export function addCorsHeaders(req: NextApiRequest, res: NextApiResponse) {
+  const config = {
+    origins: env.origins,
+    originsRegex: env.origins_regex,
+  };
+
+  if (!assertOrigin(req.headers.origin, config)) {
+    res.setHeader('Access-Control-Allow-Origin', config.origins[0]);
+  } else {
+    res.setHeader('Access-Control-Allow-Origin', req.headers.origin);
+  }
+}

--- a/lib/variables.ts
+++ b/lib/variables.ts
@@ -6,7 +6,9 @@ export const env = {
   token: process.env.GITHUB_TOKEN,
   private_key: process.env.GITHUB_PRIVATE_KEY,
   encryption_password: process.env.ENCRYPTION_PASSWORD,
-};
+  origins: JSON.parse(process.env.ORIGINS || '[]') as string[],
+  origins_regex: JSON.parse(process.env.ORIGINS_REGEX || '[]') as string[],
+} as const;
 
 export const Theme = {
   light: 'GitHub Light',

--- a/next.config.js
+++ b/next.config.js
@@ -3,18 +3,44 @@ const withBundleAnalyzer = require('@next/bundle-analyzer')({
   enabled: process.env.ANALYZE === 'true',
 });
 
+const securityHeaders = [
+  {
+    key: 'X-DNS-Prefetch-Control',
+    value: 'on'
+  },
+  {
+    key: 'X-XSS-Protection',
+    value: '1; mode=block'
+  },
+  {
+    key: 'X-Frame-Options',
+    value: 'SAMEORIGIN'
+  },
+  {
+    key: 'Permissions-Policy',
+    value: 'camera=(), microphone=(), geolocation=(), interest-cohort=()'
+  },
+  {
+    key: 'X-Content-Type-Options',
+    value: 'nosniff'
+  },
+  {
+    key: 'Referrer-Policy',
+    value: 'strict-origin-when-cross-origin'
+  },
+  {
+    key: 'Content-Security-Policy',
+    value: `frame-ancestors 'self';`,
+  }
+];
+
 module.exports = withBundleAnalyzer(
   withPreact({
     async headers() {
       return [
         {
           source: '/(.*)',
-          headers: [
-            {
-              key: 'Permissions-Policy',
-              value: 'interest-cohort=()',
-            },
-          ],
+          headers: securityHeaders,
         },
       ];
     },

--- a/pages/api/discussions/categories.ts
+++ b/pages/api/discussions/categories.ts
@@ -1,9 +1,12 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
+import { addCorsHeaders } from '../../../lib/cors';
 import { ICategories, IError } from '../../../lib/types/adapter';
 import { getAppAccessToken } from '../../../services/github/getAppAccessToken';
 import { getDiscussionCategories } from '../../../services/github/getDiscussionCategories';
 
 export default async (req: NextApiRequest, res: NextApiResponse<ICategories | IError>) => {
+  addCorsHeaders(req, res);
+
   const params = { repo: req.query.repo as string };
   const result = { repositoryId: '', categories: [] };
 

--- a/pages/api/discussions/index.ts
+++ b/pages/api/discussions/index.ts
@@ -5,6 +5,7 @@ import { IError, IGiscussion } from '../../../lib/types/adapter';
 import { createDiscussion } from '../../../services/github/createDiscussion';
 import { GRepositoryDiscussion } from '../../../lib/types/github';
 import { getAppAccessToken } from '../../../services/github/getAppAccessToken';
+import { addCorsHeaders } from '../../../lib/cors';
 
 async function get(req: NextApiRequest, res: NextApiResponse<IGiscussion | IError>) {
   const params = {
@@ -85,6 +86,7 @@ async function post(req: NextApiRequest, res: NextApiResponse<{ id: string } | I
 }
 
 export default async (req: NextApiRequest, res: NextApiResponse) => {
+  addCorsHeaders(req, res);
   if (req.method === 'POST') {
     await post(req, res);
     return;

--- a/pages/api/oauth/token.ts
+++ b/pages/api/oauth/token.ts
@@ -2,8 +2,11 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import { env } from '../../../lib/variables';
 import { decodeState } from '../../../lib/oauth/state';
 import { ITokenRequest } from '../../../lib/types/giscus';
+import { addCorsHeaders } from '../../../lib/cors';
 
 export default async (req: NextApiRequest, res: NextApiResponse) => {
+  addCorsHeaders(req, res);
+
   const { session } = req.body as ITokenRequest;
   if (!session) {
     res.status(400).json({ error: 'Unable to parse request body.' });


### PR DESCRIPTION
Part of #40.

Slightly related to https://github.com/utterance/utterances/issues/527, we set `Content-Security-Policy` with `frame-ancestors` that's set to the current origin if it's allowed according to `giscus.json` settings. As a result, we no longer show the message implemented in #125 (the browser will now simply refuse to load the `iframe`).