### PR TITLE
Use strict-origin Referrer-Policy to avoid excessive header length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ writing, this is a rolling-release project without any meaningful versioning
 whatsoever. Tags/releases may be created for the sole purpose of documenting
 major updates to the project.
 
+## 2021-07-31
+
+### changed
+
+- Use strict-origin Referrer-Policy to avoid excessive header length
+  ([#154](https://github.com/laymonage/giscus/pull/154)).
+
 ## 2021-07-25
 
 ### added

--- a/next.config.js
+++ b/next.config.js
@@ -26,7 +26,7 @@ const securityHeaders = [
   },
   {
     key: 'Referrer-Policy',
-    value: 'strict-origin-when-cross-origin'
+    value: 'strict-origin'
   },
   {
     key: 'Content-Security-Policy',


### PR DESCRIPTION
Fix #153.