### PR TITLE
Improve theme performance on initial load

### DIFF
--- a/components/Configuration.tsx
+++ b/components/Configuration.tsx
@@ -7,8 +7,8 @@ import { Theme } from '../lib/variables';
 import { getCategories } from '../services/giscus/categories';
 
 interface IDirectConfig {
-  theme: string;
-  themeUrl: string;
+  theme: Theme;
+  themeUrl: Theme;
   reactionsEnabled: boolean;
   emitMetadata: boolean;
 }
@@ -419,7 +419,7 @@ export default function Configuration({ directConfig, onDirectConfigChange }: IC
         name="theme"
         id="theme"
         value={directConfig.theme}
-        onChange={(event) => onDirectConfigChange('theme', event.target.value)}
+        onChange={(event) => onDirectConfigChange('theme', event.target.value as Theme)}
         className="px-[12px] py-[5px] pr-6 border rounded-md appearance-none bg-no-repeat form-control form-select color-border-primary color-bg-primary"
       >
         {Object.entries(Theme).map(([value, label]) => (
@@ -437,7 +437,7 @@ export default function Configuration({ directConfig, onDirectConfigChange }: IC
           <input
             id="themeUrl"
             value={directConfig.themeUrl}
-            onChange={(event) => onDirectConfigChange('themeUrl', event.target.value)}
+            onChange={(event) => onDirectConfigChange('themeUrl', event.target.value as Theme)}
             type="text"
             className="my-2 px-[12px] py-[5px] min-w-[75%] sm:min-w-[50%] form-control border rounded-md placeholder-gray-500"
             placeholder="https://giscus.app/themes/custom_example.css"

--- a/lib/context.ts
+++ b/lib/context.ts
@@ -1,4 +1,5 @@
 import { createContext } from 'react';
+import { Theme } from './variables';
 
 interface IAuthContext {
   token: string;
@@ -17,12 +18,12 @@ export const AuthContext = createContext<IAuthContext>({
 });
 
 interface IThemeContext {
-  theme: string;
-  setTheme?: (theme: string) => void;
+  theme: Theme;
+  setTheme?: (theme: Theme) => void;
 }
 
 export const ThemeContext = createContext<IThemeContext>({
-  theme: '',
+  theme: 'light',
 });
 
 interface IConfigContext {

--- a/lib/hooks.ts
+++ b/lib/hooks.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, MutableRefObject, Dispatch, SetStateAction } from 'react';
-import { resolveTheme } from './utils';
+import { getThemeUrl, resolveTheme } from './utils';
 
 export function useComponentVisible<T extends HTMLElement>(initialIsVisible: boolean) {
   const [isComponentVisible, setIsComponentVisible] = useState(initialIsVisible);
@@ -73,7 +73,7 @@ export function useTheme() {
   const [theme, setTheme] = useState('');
 
   const resolvedTheme = resolveTheme(theme);
-  const themeUrl = resolvedTheme === 'custom' ? theme : `/themes/${resolvedTheme}.css`;
+  const themeUrl = getThemeUrl(resolvedTheme, theme);
 
   useThemeChanger(themeUrl);
 

--- a/lib/hooks.ts
+++ b/lib/hooks.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, MutableRefObject, Dispatch, SetStateAction } from 'react';
-import { getTheme } from './utils';
+import { resolveTheme } from './utils';
 
 export function useComponentVisible<T extends HTMLElement>(initialIsVisible: boolean) {
   const [isComponentVisible, setIsComponentVisible] = useState(initialIsVisible);
@@ -72,7 +72,7 @@ export function useThemeChanger(themeUrl: string) {
 export function useTheme() {
   const [theme, setTheme] = useState('');
 
-  const resolvedTheme = getTheme(theme);
+  const resolvedTheme = resolveTheme(theme);
   const themeUrl = resolvedTheme === 'custom' ? theme : `/themes/${resolvedTheme}.css`;
 
   useThemeChanger(themeUrl);

--- a/lib/hooks.ts
+++ b/lib/hooks.ts
@@ -70,8 +70,8 @@ export function useThemeChanger(themeUrl: string) {
   }, [themeUrl]);
 }
 
-export function useTheme() {
-  const [theme, setTheme] = useState<Theme>('light');
+export function useTheme(initialTheme: Theme) {
+  const [theme, setTheme] = useState<Theme>(initialTheme);
 
   const resolvedTheme = resolveTheme(theme);
   const themeUrl = getThemeUrl(resolvedTheme, theme);

--- a/lib/hooks.ts
+++ b/lib/hooks.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef, MutableRefObject, Dispatch, SetStateAction } from 'react';
 import { getThemeUrl, resolveTheme } from './utils';
+import { Theme } from './variables';
 
 export function useComponentVisible<T extends HTMLElement>(initialIsVisible: boolean) {
   const [isComponentVisible, setIsComponentVisible] = useState(initialIsVisible);
@@ -70,7 +71,7 @@ export function useThemeChanger(themeUrl: string) {
 }
 
 export function useTheme() {
-  const [theme, setTheme] = useState('');
+  const [theme, setTheme] = useState<Theme>('light');
 
   const resolvedTheme = resolveTheme(theme);
   const themeUrl = getThemeUrl(resolvedTheme, theme);

--- a/lib/types/giscus.ts
+++ b/lib/types/giscus.ts
@@ -1,3 +1,4 @@
+import { Theme } from '../variables';
 import { IReactionGroups, IUser } from './adapter';
 
 export interface ITokenRequest {
@@ -43,7 +44,7 @@ export interface IMetadataMessage {
 // parent-to-giscus messages
 export interface ISetConfigMessage {
   setConfig: {
-    theme?: string;
+    theme?: Theme;
     repo?: string;
     term?: string;
     number?: number;

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -4,13 +4,13 @@ import format from 'date-fns/format';
 import formatDistanceStrict from 'date-fns/formatDistanceStrict';
 import { Theme } from './variables';
 
-export function resolveTheme(theme: string): Theme {
+export function resolveTheme(theme: Theme): Theme {
   if (!theme) return 'light';
   if (theme in Theme) return theme as Theme;
   return 'custom';
 }
 
-export function getThemeUrl(resolvedTheme: Theme, theme: string) {
+export function getThemeUrl(resolvedTheme: Theme, theme: Theme): Theme {
   return resolvedTheme === 'custom' ? theme : `/themes/${resolvedTheme}.css`;
 }
 

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -4,7 +4,7 @@ import format from 'date-fns/format';
 import formatDistanceStrict from 'date-fns/formatDistanceStrict';
 import { Theme } from './variables';
 
-export function getTheme(theme: string): Theme {
+export function resolveTheme(theme: string): Theme {
   if (!theme) return 'light';
   if (theme in Theme) return theme as Theme;
   return 'custom';

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -10,6 +10,10 @@ export function resolveTheme(theme: string): Theme {
   return 'custom';
 }
 
+export function getThemeUrl(resolvedTheme: Theme, theme: string) {
+  return resolvedTheme === 'custom' ? theme : `/themes/${resolvedTheme}.css`;
+}
+
 export function getOriginHost(origin: string) {
   try {
     return new URL(origin).origin;

--- a/lib/variables.ts
+++ b/lib/variables.ts
@@ -20,4 +20,4 @@ export const Theme = {
   custom: 'Custom (experimental)',
 } as const;
 
-export type Theme = keyof typeof Theme;
+export type Theme = keyof typeof Theme | `/${string}` | `https://${string}`;

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -19,7 +19,7 @@ const meta = {
 };
 
 export default function App({ Component, pageProps }: AppProps) {
-  const { resolvedTheme, setTheme } = useTheme();
+  const { resolvedTheme, setTheme } = useTheme(pageProps.theme);
 
   return (
     <ThemeContext.Provider value={{ theme: resolvedTheme, setTheme }}>

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -1,7 +1,14 @@
 import Document, { Html, Head, Main, NextScript } from 'next/document';
+import { getThemeUrl, resolveTheme } from '../lib/utils';
 
 class CustomDocument extends Document {
   render() {
+    // Use the `theme` prop of the page if available
+    // to immediately set the correct theme.
+    const theme = this.props.__NEXT_DATA__.props.pageProps.theme;
+    const resolvedTheme = resolveTheme(theme || 'light');
+    const themeUrl = getThemeUrl(resolvedTheme, theme);
+
     return (
       <Html lang="en">
         <Head>
@@ -14,12 +21,7 @@ class CustomDocument extends Document {
           <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
           <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
           <link rel="manifest" href="/site.webmanifest" />
-          <link
-            rel="stylesheet"
-            href="/themes/light.css"
-            crossOrigin="anonymous"
-            id="giscus-theme"
-          />
+          <link rel="stylesheet" href={themeUrl} crossOrigin="anonymous" id="giscus-theme" />
         </Head>
         <body>
           <Main />

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -11,6 +11,8 @@ import { ComponentProps, useContext, useEffect, useState } from 'react';
 import { ThemeContext } from '../lib/context';
 import { sendData } from '../lib/messages';
 import { ISetConfigMessage } from '../lib/types/giscus';
+import { getThemeUrl } from '../lib/utils';
+import { Theme } from '../lib/variables';
 
 export const getStaticProps = async () => {
   const path = join(process.cwd(), 'README.md');
@@ -49,25 +51,25 @@ export default function Home({ contentBefore, contentAfter }: HomeProps) {
     emitMetadata: false,
   });
   const themeUrl = useDebounce(directConfig.themeUrl);
-  const resolvedTheme = directConfig.theme === 'custom' ? themeUrl : directConfig.theme;
+  const configTheme = getThemeUrl(directConfig.theme as Theme, themeUrl);
 
   const handleDirectConfigChange: DirectConfigHandler = (key, value) =>
     setDirectConfig({ ...directConfig, [key]: value });
 
   useEffect(() => {
-    setTheme(resolvedTheme);
-  }, [setTheme, resolvedTheme]);
+    setTheme(configTheme);
+  }, [setTheme, configTheme]);
 
   useEffect(() => {
     const data: ISetConfigMessage = {
       setConfig: {
-        theme: resolvedTheme,
+        theme: configTheme,
         reactionsEnabled: directConfig.reactionsEnabled,
         emitMetadata: directConfig.emitMetadata,
       },
     };
     sendData(data, location.origin);
-  }, [directConfig.emitMetadata, directConfig.reactionsEnabled, resolvedTheme, themeUrl]);
+  }, [directConfig.emitMetadata, directConfig.reactionsEnabled, configTheme, themeUrl]);
 
   useEffect(() => {
     const script = document.createElement('script');

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -12,7 +12,6 @@ import { ThemeContext } from '../lib/context';
 import { sendData } from '../lib/messages';
 import { ISetConfigMessage } from '../lib/types/giscus';
 import { getThemeUrl } from '../lib/utils';
-import { Theme } from '../lib/variables';
 
 export const getStaticProps = async () => {
   const path = join(process.cwd(), 'README.md');
@@ -46,12 +45,12 @@ export default function Home({ contentBefore, contentAfter }: HomeProps) {
   const { theme, setTheme } = useContext(ThemeContext);
   const [directConfig, setDirectConfig] = useState<DirectConfig>({
     theme: 'light',
-    themeUrl: '',
+    themeUrl: 'https://',
     reactionsEnabled: true,
     emitMetadata: false,
   });
   const themeUrl = useDebounce(directConfig.themeUrl);
-  const configTheme = getThemeUrl(directConfig.theme as Theme, themeUrl);
+  const configTheme = getThemeUrl(directConfig.theme, themeUrl);
 
   const handleDirectConfigChange: DirectConfigHandler = (key, value) =>
     setDirectConfig({ ...directConfig, [key]: value });

--- a/pages/widget.tsx
+++ b/pages/widget.tsx
@@ -7,7 +7,7 @@ import { ConfigContext, ThemeContext } from '../lib/context';
 import { decodeState } from '../lib/oauth/state';
 import { ISetConfigMessage } from '../lib/types/giscus';
 import { getOriginHost } from '../lib/utils';
-import { env } from '../lib/variables';
+import { env, Theme } from '../lib/variables';
 import { getAppAccessToken } from '../services/github/getAppAccessToken';
 import { getRepoConfig } from '../services/github/getConfig';
 
@@ -23,7 +23,7 @@ export async function getServerSideProps({ query, res }: GetServerSidePropsConte
   const description = (query.description as string) || '';
   const reactionsEnabled = Boolean(+query.reactionsEnabled);
   const emitMetadata = Boolean(+query.emitMetadata);
-  const theme = (query.theme as string) || '';
+  const theme = ((query.theme as string) || 'light') as Theme;
   const originHost = getOriginHost(origin);
 
   const { encryption_password } = env;


### PR DESCRIPTION
This PR attempts to prevent flash of themes on initial load of the widget page. This is done by reading the page's `theme` prop if exists and using it in the document's `Head`.

We can't use `Head` from `next/head` because it doesn't like modifications from the client in development mode.